### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ curl -X POST https://api.shapes.inc/v1/chat/completions \
 | Feature | Details |
 |---------|---------|
 | Endpoints | `/chat/completions` |
-| Rate Limits | 5 RPM (request increase [here](https://docs.google.com/forms/d/e/1FAIpQLScGLeRk6snViRPslXbbUaMDwubcBhmcJ6opq7wFvPEp-EbO3g/viewform)) |
+| Rate Limits | 20 RPM (request increase [here](https://docs.google.com/forms/d/e/1FAIpQLScGLeRk6snViRPslXbbUaMDwubcBhmcJ6opq7wFvPEp-EbO3g/viewform)) |
 | Headers | `X-User-Id` for user identification, `X-Channel-Id` for conversation context |
 | Response Format | Standard OpenAI-compatible JSON response |
 
@@ -218,6 +218,7 @@ Note: Shapes set on Premium Engines **WILL** use credits when accessed via API.
 - [x] IRC
 - [x] Chess
 - [x] Voice
+- [x] Twitch
 - [x] GitHub (to review PRs)
 
 ## Requested Integrations
@@ -226,7 +227,6 @@ We're looking for developer contributions to build:
 - [ ] Threads
 - [ ] Roblox
 - [ ] Minecraft
-- [ ] Twitch
 - [ ] LinkedIn
 - [ ] Microsoft Teams
 - [ ] WeChat


### PR DESCRIPTION
This PR updates outdated rate-limit information in the README and moves the Twitch integration from "Requested Integrations" to "Available Integrations".

## Why

The README was showing outdated information, such as the default rate limit being 5 RPM:
![image](https://github.com/user-attachments/assets/bcf3d5fe-222e-4d78-9785-ed8c746a3467)
Now that the default rate limit is 20 RPM, this outdated info could have led users to request a rate limit increase unnecessarily.

## What Changed

* Updated the default rate-limit information
* Moved Twitch integration to the correct section

## Test Plan

This is a README update, so it shouldn't break anything.

## Additional Notes

**Note to the reviewer:**
While we mention custom headers in the README, I believe we should give this topic more attention and explain how they work.

Just now, someone asked if running the `!reset` command on their shape would reset memories for all users. If they are using custom headers, it shouldn't affect all users. But if not, all user memories are mixed, and any user could delete all memories - which is not ideal.

So I suggest updating the "Custom Headers" section in the README. If you agree, please do not merge this PR and leave a comment instead. I'll update the README accordingly. Also, please confirm that using custom headers separates memories and improves system security.

Thank you!
