### PR TITLE
Update: Add details about profile endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,61 @@ You can send audio URLs in the API request using this format:
 
 Supported audio formats: mp3, wav, ogg
 
+## API Endpoints
+### Get Shape Profile Data
+Retrieve detailed information about any shape using their username.
+
+**Endpoint:**
+```
+GET https://api.shapes.inc/shapes/public/{username}
+```
+
+**Cross-Platform Examples:**
+
+**Linux/macOS/Git Bash:**
+```bash
+curl "https://api.shapes.inc/shapes/public/{username}"
+```
+
+**Windows Command Prompt:**
+```cmd
+curl "https://api.shapes.inc/shapes/public/einstein"
+```
+
+**Windows PowerShell:**
+```powershell
+curl.exe "https://api.shapes.inc/shapes/public/{username}"
+```
+
+**Example code:**
+```javascript
+async function getShapeProfile(username = 'tenshi') { 
+    try {
+        const response = await fetch(`https://api.shapes.inc/shapes/public/${username}`);
+        const data = await response.json();
+        
+        // key fields to be extracted
+        const description = data.search_description;
+        const avatar = data.avatar || data.avatar_url;
+        
+        console.log(`Name: ${data.name}`);
+        console.log(`Description: ${description}`);
+        console.log(`Avatar: ${avatar}`);
+        
+        return { description, avatar };
+    } catch (error) {
+        console.log(`Error: ${error.message}`);
+    }
+}
+
+getShapeProfile(process.argv[2]); 
+```
+**Output:**
+```plaintext
+Name: tenshi
+Description: yo! am tenshi, am better am cooler
+Avatar: https://files.shapes.inc/api/files/avatar_aca2e51a-e79c-417a-9515-be27fa624a0c.png
+```
 ## Important Notes
 
 ### Current Limitations

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Star and contribute to this repository to receive free hosting for your integrat
 Shapes API provides a programmatic way to integrate Shapes into any application or platform. It follows the OpenAI-compatible API standard, making it easy to implement with existing libraries and SDKs.
 
 ## Demos
-To get a sense of what’s possible, see what people have already built: 
+To get a sense of what's possible, see what people have already built: 
 
 - Omegle with Shapes https://omegle-ai.vercel.app by [@khawajapartners](https://github.com/zahidkhawaja)
 - Playing Chess with Shapes https://shapeschess.vercel.app by [@kiyosh11](https://github.com/kiyosh11)
@@ -231,13 +231,23 @@ curl "https://api.shapes.inc/shapes/public/{username}"
 
 **Windows Command Prompt:**
 ```cmd
-curl "https://api.shapes.inc/shapes/public/einstein"
+curl "https://api.shapes.inc/shapes/public/{username}"
 ```
 
 **Windows PowerShell:**
 ```powershell
 curl.exe "https://api.shapes.inc/shapes/public/{username}"
 ```
+
+**Endpoint Details:**
+- **URL**: `https://api.shapes.inc/shapes/public/{username}`
+- **Method**: `GET`
+- **Authentication**: None required (public endpoint)
+- **Rate Limits**: Standard API rate limits apply
+- **Response Format**: JSON
+
+<details>
+<summary><strong>📋 Complete Example Code & Response</strong> (Click to expand)</summary>
 
 **Example code:**
 ```javascript
@@ -246,28 +256,114 @@ async function getShapeProfile(username = 'tenshi') {
         const response = await fetch(`https://api.shapes.inc/shapes/public/${username}`);
         const data = await response.json();
         
-        // key fields to be extracted
-        const description = data.search_description;
-        const avatar = data.avatar || data.avatar_url;
+        // Display all available fields
+        console.log('=== Complete Shape Profile ===');
+        console.log(JSON.stringify(data, null, 2));
         
-        console.log(`Name: ${data.name}`);
-        console.log(`Description: ${description}`);
-        console.log(`Avatar: ${avatar}`);
+        // Extract commonly used fields
+        const {
+            id, name, username, search_description, search_tags_v2,
+            created_ts, user_count, message_count, tagline,
+            typical_phrases, screenshots, category, character_universe,
+            character_background, avatar_url, avatar, banner,
+            shape_settings, example_prompts, enabled
+        } = data;
         
-        return { description, avatar };
+        console.log(`\n=== Key Information ===`);
+        console.log(`Name: ${name}`);
+        console.log(`Username: ${username}`);
+        console.log(`Description: ${search_description}`);
+        console.log(`Category: ${category}`);
+        console.log(`Universe: ${character_universe}`);
+        console.log(`Users: ${user_count?.toLocaleString() || 'N/A'}`);
+        console.log(`Messages: ${message_count?.toLocaleString() || 'N/A'}`);
+        console.log(`Avatar: ${avatar_url || avatar}`);
+        console.log(`Enabled: ${enabled}`);
+        
+        return data; // Return complete profile data
     } catch (error) {
         console.log(`Error: ${error.message}`);
+        return null;
     }
 }
 
-getShapeProfile(process.argv[2]); 
+// Usage examples
+getShapeProfile('tenshi');           // Get tenshi's profile
+getShapeProfile('einstein');         // Get einstein's profile
+getShapeProfile(process.argv[2]);    // Get profile from command line argument
 ```
-**Output:**
-```plaintext
-Name: tenshi
-Description: yo! am tenshi, am better am cooler
-Avatar: https://files.shapes.inc/api/files/avatar_aca2e51a-e79c-417a-9515-be27fa624a0c.png
+
+**Available API Fields:**
+The API returns comprehensive shape data including:
+- `id` - Unique shape identifier (UUID)
+- `name` - Display name of the shape
+- `username` - Unique username for API calls
+- `search_description` - Shape description for search/discovery
+- `search_tags_v2` - Array of searchable tags
+- `created_ts` - Creation timestamp (Unix timestamp)
+- `user_count` - Number of users who have interacted
+- `message_count` - Total messages sent by the shape
+- `tagline` - Custom tagline/bio
+- `typical_phrases` - Array of characteristic phrases
+- `screenshots` - Array of conversation screenshots with captions
+- `category` - Shape category (e.g., "meme", "educational")
+- `character_universe` - Source universe/franchise
+- `character_background` - Background story/lore
+- `avatar_url` / `avatar` - Profile image URLs
+- `banner` - Banner image URL
+- `shape_settings` - Configuration (initial message, status, etc.)
+- `example_prompts` - Suggested conversation starters
+- `enabled` - Whether the shape is currently active
+- `allow_user_engine_override` - Engine override permissions
+- `error_message` - Error message
+- `wack_message` - Wack message
+
+**Sample Response:**
+```json
+{
+  "id": "aca2e51a-e79c-417a-9515-be27fa624a0c",
+  "name": "tenshi",
+  "username": "tenshi",
+  "search_description": "yo! am tenshi, am better am cooler",
+  "search_tags_v2": [
+    "cool", "character ai", "tenshi", "ai chatbot", "maverick",
+    "modern", "short messages", "mischief", "chill", "informal"
+  ],
+  "created_ts": 1690601301,
+  "user_count": 122320,
+  "message_count": 7918988,
+  "tagline": "tenshi by dhruv, the most humanlike shape out there",
+  "typical_phrases": ["ur mom"],
+  "screenshots": [
+    {
+      "id": 1743863106924,
+      "url": "https://files.shapes.inc/b4866ca3.png",
+      "caption": "offended tenshi"
+    },
+    {
+      "id": 1743863288091,
+      "url": "https://files.shapes.inc/a63515d9.png",
+      "caption": "random tenshi"
+    }
+  ],
+  "category": "meme",
+  "character_universe": "Touhou Project",
+  "character_background": "no background, just foreground!",
+  "avatar_url": "https://files.shapes.inc/avatar_aca2e51a-e79c-417a-9515-be27fa624a0c.png",
+  "banner": "https://files.shapes.inc/api/files/banner_aca2e51a-e79c-417a-9515-be27fa624a0c.png",
+  "shape_settings": {
+    "shape_initial_message": "hey {user}, sup",
+    "status_type": "custom",
+    "status": "😎 trendsetter",
+    "appearance": ""
+  },
+  "example_prompts": ["have fun, maximum fun!"],
+  "enabled": true
+}
 ```
+
+</details>
+
 ## Important Notes
 
 ### Current Limitations


### PR DESCRIPTION
Windows methods have been tested locally. I couldnt test Linux/Mac methods, but they are standard so they should work fine. Please test with a Mac/Linux device if possible.

Before merging the PR-

@nooriedhingra I would like you to review it and make sure we really want to keep it this way. Currently we dont ask the user for an API key for requesting this information.

## Why
This will help developers get **shape profile details** such as profile pictures, banners, and descriptions.

## What Changed
I updated the **readme** and added information about **API calls**.