### PR TITLE
fix(debugger): make response body human readable

### DIFF
--- a/tools/debugger/package-lock.json
+++ b/tools/debugger/package-lock.json
@@ -33,7 +33,7 @@
                 "typescript-eslint": "^8.33.1"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=22"
             }
         },
         "node_modules/@emnapi/core": {

--- a/tools/debugger/package.json
+++ b/tools/debugger/package.json
@@ -57,6 +57,6 @@
         "typescript-eslint": "^8.33.1"
     },
     "engines": {
-        "node": ">=18"
+        "node": ">=22"
     }
 }

--- a/tools/debugger/src/main.ts
+++ b/tools/debugger/src/main.ts
@@ -266,6 +266,20 @@ function prettyPrintResponseBody(res: http.IncomingMessage, bodyBuf: Buffer): vo
       console.log(chalk.red('Failed to decompress gzipped response:'), (err as Error).message);
       console.log(chalk.gray('Raw gzipped data length:'), bodyBuf.length);
     }
+  } else if (contentEncoding === 'zstd') {
+    try {
+      const decompressed = zlib.zstdDecompressSync(bodyBuf);
+      const str = decompressed.toString('utf-8');
+      try {
+        const obj = JSON.parse(str);
+        prettyPrintJson(obj, { isResponse: true });
+      } catch {
+        console.log(str);
+      }
+    } catch (err) {
+      console.log(chalk.red('Failed to decompress zstd response:'), (err as Error).message);
+      console.log(chalk.gray('Raw zstd data length:'), bodyBuf.length);
+    }
   } else {
     const str = bodyBuf.toString('utf8');
     try {

--- a/tools/debugger/src/main.ts
+++ b/tools/debugger/src/main.ts
@@ -165,9 +165,10 @@ function prettyPrintRequest(req: http.IncomingMessage, bodyBuf: Buffer): void {
  */
 function isStreamingResponse(res: http.IncomingMessage): boolean {
   const contentType = res.headers['content-type'] || '';
-  return contentType.includes('text/event-stream') ||
-         contentType.includes('application/x-ndjson') ||
-         res.headers['transfer-encoding'] === 'chunked';
+
+  // Chunked transfer encoding alone doesn't always indicate a proper stream
+  return contentType.includes('text/event-stream') && res.headers['transfer-encoding'] === 'chunked' ||
+    contentType.includes('application/x-ndjson') && res.headers['transfer-encoding'] === 'chunked';
 }
 
 /**


### PR DESCRIPTION
## Why
<!-- Why is this change necessary? What problem does it solve? -->
Prevent response body looking like gibberish

## What Changed
<!-- What are the key changes in this PR? List major functionality changes/additions -->
Decompresses incoming zstd encoded response body to human readable JSON string

## Test Plan
<!-- How have you tested these changes? Include steps to reproduce and verify -->
N/A

## Integration Details
<!-- If this is a new integration, provide the following info -->
N/A

## Screenshots/Examples
<!-- If applicable, add screenshots or examples of the integration working -->
| Before | After |
|-------|-------|
|![image](https://github.com/user-attachments/assets/993a768f-60d8-407e-9918-a232cb2a810e)|![image](https://github.com/user-attachments/assets/1d1d4a94-0831-473b-b230-af5a1e12d71a)|

## Checklist

- [X] I have tested my changes locally
- [X] My code follows the project's style guidelines
- [X] I have updated relevant documentation
- [X] I have added appropriate error handling
- [X] I have considered security implications

## Additional Notes
<!-- Any other context or notes about this PR --> 
N/A